### PR TITLE
Include sessions table migration file

### DIFF
--- a/database/migrations/2024_09_10_110901_create_sessions_table.php
+++ b/database/migrations/2024_09_10_110901_create_sessions_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sessions', function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->foreignId('user_id')->nullable()->index();
+            $table->string('ip_address', 45)->nullable();
+            $table->text('user_agent')->nullable();
+            $table->longText('payload');
+            $table->integer('last_activity')->index();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sessions');
+    }
+};


### PR DESCRIPTION
What and Why:

Create a sessions_table migration file by running `php artisan make:session-table`

This is added because the new .env files from laravel/laravel use database as the default driver for the sessions instead of the file based session. If a user downloads a .env file using the current env.example, not having the sessions table will cause an error because of this.