### PR TITLE
Fix article readme, handle when no documents in db

### DIFF
--- a/_readme/display_isolated_fly_replay_livewire.md
+++ b/_readme/display_isolated_fly_replay_livewire.md
@@ -2,7 +2,7 @@
 
 Running global instances of our Laravel applications allows us to reduce geographical latency for users across different regions. But with it comes the responsibility of addressing regional-isolation of not only data, but files as well.
 
-In [this article](/laravel-bytes/displaying-fly-replay-livewire/) we address file isolation by talking with the right regional instance using fly-replay. We also add a cherry on top with the use of Livewire's `wire:init` directive to improve loading of pages displaying PDF files.
+In [this article](https://fly.io/laravel-bytes/displaying-fly-replay-livewire/) we address file isolation by talking with the right regional instance using fly-replay. We also add a cherry on top with the use of Livewire's `wire:init` directive to improve loading of pages displaying PDF files.
 
 ## Relevant files
 1. We've added routes to a documents module in [`web.php`](https://github.com/KTanAug21/fly.io-livewire-snippets/blob/master/routes/web.php)

--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -28,9 +28,13 @@ class DocumentController extends Controller
     public function display($id)
     {
         $pdfDetails = Document::find($id);
-        Log::info('our config var value is '.config('app.fly_region') );
-        
+        // None found, don
+        if ( $pdfDetails == null ){
+            return null;
+        }
+
         // Decide replay
+        Log::info('our config var value is '.config('app.fly_region') );
         if( $pdfDetails->region_id != config('app.fly_region') ){     
 
             // Replay to identified region


### PR DESCRIPTION
What and Why:

Fix details found in the section for delaying display of pdf files:
1. Fix link to article
2. Handle when the documents table does not contain any row